### PR TITLE
Ability to override host header.

### DIFF
--- a/src/lunatic_impl/client/mod.rs
+++ b/src/lunatic_impl/client/mod.rs
@@ -335,7 +335,9 @@ impl InnerClient {
         }
 
         if let Some(host) = url.host() {
-            headers.append("Host", HeaderValue::from_str(&host.to_string()).unwrap());
+            if !self.headers.contains_key("Host") {
+                headers.append("Host", HeaderValue::from_str(&host.to_string()).unwrap());
+            }
         }
 
         // insert default headers in the request headers


### PR DESCRIPTION
I plan to merge this upstream as well.

Basically I need to override the host field to interact with a particular application. I think the default behavior is correct, but when specifying `host` in any context such as using `.header` or `.headers` or `.default_headers` the host header is specified twice. This causes issues with servers who expect a single host header. This fixes the issue by only adding the host header if it isn't present in the passed headers.